### PR TITLE
fix: don't disconnect on error by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,8 @@ module.exports = ({utMeta, utPort, utMethod}) => class SchedulePort extends utPo
         return {
             jobsList: {},
             type: 'schedule',
-            listen: false
+            listen: false,
+            disconnectOnError: false
         };
     }
 


### PR DESCRIPTION
By default, the scheduler port disconnects and stops all jobs after unhandled errors. I think that this is unexpected behavior.

If there is intention to stop jobs on unhandled errors, it would be better to be done per job, instead of the whole port. Also, the same behavior can be achieved explicitly by using `this.disconnect()`